### PR TITLE
fix: Unsupported parameters for (ansible.legacy.command) module: warn

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: restart adguard
-  systemd:
+- name: Restart adguard
+  ansible.builtin.systemd:
     daemon_reload: true
     name: adguard
     state: restarted
   become: true
   tags: adguard
 
-- name: reload adguard
-  systemd:
+- name: Reload adguard
+  ansible.builtin.systemd:
     name: adguard
     state: reloaded
   become: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,9 @@ galaxy_info:
       versions:
         - focal
         - bionic
+    - name: Debian
+      versions:
+        - bullseye
   galaxy_tags:
   - system
   - network

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Dominik Lenhardt
   description: Installing and configure ad-blocking DNS-server Adguard Home (https://github.com/AdguardTeam/AdGuardHome).
   license: "MIT"
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,8 +52,6 @@
 
 - name: gather currently installed version (if any)
   command: "{{ adguard_binary_install_dir }}/adguard --version"
-  args:
-    warn: false
   changed_when: false
   register: __adguard_current_version_output
   when: __adguard_is_installed.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: install dependencies
-  apt:
+- name: Install dependencies
+  ansible.builtin.apt:
     name:
       - gnupg
       - ca-certificates
@@ -12,16 +12,16 @@
   become: yes
   tags: adguard
 
-- name: create system group
-  group:
+- name: Create system group
+  ansible.builtin.group:
     name: "{{ adguard_system_group }}"
     system: true
     state: present
   become: true
   tags: adguard
 
-- name: create system user
-  user:
+- name: Create system user
+  ansible.builtin.user:
     name: "{{ adguard_system_user }}"
     system: true
     shell: "/usr/sbin/nologin"
@@ -30,42 +30,42 @@
   become: true
   tags: adguard
 
-- name: create directories
-  file:
+- name: Create directories
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ adguard_system_user }}"
     group: "{{ adguard_system_group }}"
-    mode: 0755
+    mode: "0755"
   with_items:
     - "{{ adguard_config_dir }}"
     - "{{ adguard_db_dir }}"
   become: true
   tags: adguard
 
-- name: check if is installed
-  stat:
+- name: Check if is installed
+  ansible.builtin.stat:
     path: "{{ adguard_binary_install_dir }}/adguard"
   register: __adguard_is_installed
   become: true
   tags: adguard
 
-- name: gather currently installed version (if any)
-  command: "{{ adguard_binary_install_dir }}/adguard --version"
+- name: Gather currently installed version (if any)
+  ansible.builtin.command: "{{ adguard_binary_install_dir }}/adguard --version"
   changed_when: false
   register: __adguard_current_version_output
   when: __adguard_is_installed.stat.exists
   become: true
   tags: adguard
 
-- name: "set installed adguard version to {{ __adguard_current_version_output.stdout_lines[0].split(' ')[3][1:] }}"
-  set_fact:
+- name: "Set installed adguard version to {{ __adguard_current_version_output.stdout_lines[0].split(' ')[3][1:] }}"
+  ansible.builtin.set_fact:
     adguard_installed_version:  "{{ __adguard_current_version_output.stdout_lines[0].split(' ')[3][1:] }}"
   when: __adguard_is_installed.stat.exists
   tags: adguard
 
-- name: get latest release
-  uri:
+- name: Get latest release
+  ansible.builtin.uri:
     url: "https://api.github.com/repos/AdguardTeam/AdGuardHome/releases/latest"
     method: GET
     return_content: true
@@ -83,15 +83,15 @@
   tags: adguard
   when: adguard_version == "latest"
 
-- name: "set version to {{ _latest_release.json.tag_name[1:] }}"
-  set_fact:
+- name: "Set version to {{ _latest_release.json.tag_name[1:] }}"
+  ansible.builtin.set_fact:
     adguard_version: "{{ _latest_release.json.tag_name[1:] }}"
   become: true
   tags: adguard
   when: adguard_version == "latest"
 
 
-- name: create a temporary directory
+- name: Create a temporary directory
   ansible.builtin.tempfile:
     state: directory
     suffix: adguard
@@ -99,10 +99,13 @@
   tags: adguard
   when: (not __adguard_is_installed.stat.exists) or (adguard_installed_version != adguard_version)
 
-- name: download binary 
-  get_url:
+- name: Download binary 
+  ansible.builtin.get_url:
     url: "https://github.com/AdguardTeam/AdGuardHome/releases/download/v{{ adguard_version }}/AdGuardHome_linux_{{ go_arch }}.tar.gz"
     dest: "{{ adguard_local_tempdir.path }}/adguard-{{ adguard_version }}.linux-{{ go_arch }}.tar.gz"
+    owner: "{{ adguard_system_user }}"
+    group: "{{ adguard_system_group }}"
+    mode: "0755"
   environment: "{{ proxy_env }}"
   register: _download_archive
   until: _download_archive is succeeded
@@ -113,8 +116,8 @@
   tags: adguard
   when: (not __adguard_is_installed.stat.exists) or (adguard_installed_version != adguard_version)
 
-- name: unpack binaries
-  unarchive:
+- name: Unpack binaries
+  ansible.builtin.unarchive:
     src: "{{ adguard_local_tempdir.path }}/adguard-{{ adguard_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "{{ adguard_local_tempdir.path }}"
     remote_src: yes
@@ -122,56 +125,56 @@
   tags: adguard
   when: (not __adguard_is_installed.stat.exists) or (adguard_installed_version != adguard_version)
 
-- name: propagate binaries
-  copy:
+- name: Propagate binaries
+  ansible.builtin.copy:
     src: "{{ adguard_local_tempdir.path }}/AdGuardHome/AdGuardHome"
     dest: "{{ adguard_binary_install_dir }}/adguard"
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
     remote_src: yes
-  notify: restart adguard
+  notify: Restart adguard
   become: true
   tags: adguard
   when: (not __adguard_is_installed.stat.exists) or (adguard_installed_version != adguard_version)
 
-- name: remove temporary files
+- name: Remove temporary files
   ansible.builtin.file:
     path: "{{ adguard_local_tempdir.path }}"
     state: absent
   tags: adguard
   when: (not __adguard_is_installed.stat.exists) or (adguard_installed_version != adguard_version)
 
-- name: copy adguard config
-  template:
+- name: Copy adguard config
+  ansible.builtin.template:
     force: true
     src: config.yaml.j2
     dest: "{{ adguard_config_dir }}/config.yaml"
     owner: "{{ adguard_system_user }}"
     group: "{{ adguard_system_group }}"
-    mode: 0644
+    mode: "0644"
     validate: "{{ adguard_binary_install_dir }}/adguard --check-config -c %s"
-  notify: reload adguard
+  notify: Reload adguard
   become: true
   tags:
     - adguard
     - adguard_config
 
-- name: create systemd service unit
-  template:
+- name: Create systemd service unit
+  ansible.builtin.template:
     src: adguard.service.j2
     dest: /etc/systemd/system/adguard.service
     owner: root
     group: root
-    mode: 0644
-  notify: restart adguard
+    mode: "0644"
+  notify: Restart adguard
   become: true
   tags:
     - adguard
     - adguard_config
 
-- name: start and enable adguard service
-  systemd:
+- name: Start and enable adguard service
+  ansible.builtin.systemd:
     daemon_reload: true
     name: adguard
     state: started


### PR DESCRIPTION
On the latest version of ansible, this role would fail with the following error
`fatal: [adguard.pwcasa.local]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends."}`

This PR should fix the issue.

I've also applied some ansible-lint suggestions as some of these might improve support for future versions of ansible.